### PR TITLE
In read-toplevel-form, don't error if a package designator was found

### DIFF
--- a/cocoa-ide/cocoa-listener.lisp
+++ b/cocoa-ide/cocoa-listener.lisp
@@ -129,8 +129,11 @@
                                      (list pathname pathname (and pathname (or (probe-file pathname) pathname)) nil
                                            source-map))))
                       (when package-name
-                        (push '*package* (car env))
-                        (push (ccl::pkg-arg package-name) (cdr env)))
+                        (let ((pkg-arg (ignore-errors (ccl::pkg-arg package-name))))
+                          ; sometimes a form in a buffer contains fully-qualified symbols,
+                          (when pkg-arg ; and such symbols don't require the buffer's package to be defined
+                            (push '*package* (car env))
+                            (push pkg-arg (cdr env)))))
                       (if source-map
                         (clrhash source-map)
                         (setf source-map (make-hash-table :test 'eq :shared nil)))


### PR DESCRIPTION
In read-toplevel-form, don't error if a package designator was found
in buffer but it's not yet defined, because it's perfectly okay to
call #'eval-region of a form with fully-qualified symbols even if such
a form appears in a buffer with an undefined package designator.
    
In cases where the symbols are not fully-qualified, an
undefined-function error will be thrown, and that's fine.
    
In other words, the behavior when forms are read from a buffer with an
undefined package designator should be identical to what happens when
no package designator exists at all.